### PR TITLE
feat: UIProviderを使用したテストユーティリティの改善

### DIFF
--- a/__tests__/README.md
+++ b/__tests__/README.md
@@ -1,0 +1,102 @@
+# テストユーティリティの使用方法
+
+## カスタムテストユーティリティ
+
+プロジェクトでは、Yamada UIコンポーネントを正しくテストするためのカスタムテストユーティリティを提供しています。
+
+### test-utils.tsx の使用
+
+```tsx
+// 従来の@testing-library/reactの代わりにカスタムrenderを使用
+import { render, screen, fireEvent } from "../../test-utils";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+```
+
+### 主な機能
+
+#### 1. UIProviderラッパー
+
+- デフォルトでUIProviderでコンポーネントをラップします
+- Yamada UIのテーマやコンテキストが正しく適用されます
+
+```tsx
+// デフォルトでUIProviderが適用される
+render(<YourComponent />);
+
+// UIProviderを無効にしたい場合
+render(<YourComponent />, { withProvider: false });
+```
+
+#### 2. カスタムプロバイダー設定
+
+```tsx
+// UIProviderにカスタムプロパティを渡す
+render(<YourComponent />, {
+  providerProps: {
+    theme: customTheme,
+    colorMode: "dark",
+  },
+});
+```
+
+#### 3. user-eventの統合
+
+```tsx
+// userオブジェクトが自動的に利用可能
+const { user } = render(<YourComponent />);
+await user.click(screen.getByText("ボタン"));
+```
+
+### セットアップファイル
+
+`__tests__/setup.ts` では以下のモックが設定されています：
+
+- `window.matchMedia` - レスポンシブデザインのテスト用
+- `ResizeObserver` - サイズ変更の監視用
+- `IntersectionObserver` - 可視性の監視用
+
+### 使用例
+
+```tsx
+import { render, screen, fireEvent } from "../../test-utils";
+import { describe, test, expect, vi } from "vitest";
+import { MyComponent } from "./MyComponent";
+
+describe("MyComponent", () => {
+  test("正しく表示される", () => {
+    render(<MyComponent />);
+
+    expect(screen.getByText("期待するテキスト")).toBeInTheDocument();
+  });
+
+  test("クリックイベントが動作する", async () => {
+    const handleClick = vi.fn();
+    const { user } = render(<MyComponent onClick={handleClick} />);
+
+    await user.click(screen.getByRole("button"));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+### 既存のテストファイルの移行
+
+1. インポートを変更：
+
+```tsx
+// 変更前
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// 変更後
+import { screen, fireEvent } from "@testing-library/react";
+import { render } from "../../test-utils";
+```
+
+2. UIProviderが適用されることで、以前は失敗していたYamada UIコンポーネントのテストが正常に動作するようになります。
+
+## 注意事項
+
+- すべてのYamada UIコンポーネントをテストする際は、このカスタムrenderを使用してください
+- プレーンなReactコンポーネント（UIライブラリを使用しない）の場合は、`withProvider: false`を指定できます
+- テストが遅い場合は、必要に応じてUIProviderを無効にすることを検討してください

--- a/__tests__/components/editor/label-editor.test.tsx
+++ b/__tests__/components/editor/label-editor.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { LabelEditor } from "../../../components/editor/label-editor";
+import { render } from "../../test-utils";
 
 describe("LabelEditor", () => {
   const defaultProps = {

--- a/__tests__/components/editor/variable-name-editor.test.tsx
+++ b/__tests__/components/editor/variable-name-editor.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { VariableNameEditor } from "../../../components/editor/variable-name-editor";
+import { render } from "../../test-utils";
 
 describe("VariableNameEditor", () => {
   const defaultProps = {

--- a/__tests__/components/flow/arrow-type-selector.test.tsx
+++ b/__tests__/components/flow/arrow-type-selector.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { ArrowTypeSelector } from "../../../components/flow/arrow-type-selector";
 import { MermaidArrowType, ARROW_TYPES } from "../../../components/types/types";
+import { render } from "../../test-utils";
 
 describe("ArrowTypeSelector", () => {
   const defaultProps = {

--- a/__tests__/components/flow/edge-content.test.tsx
+++ b/__tests__/components/flow/edge-content.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { EdgeContent } from "../../../components/flow/editable-edge";
+import { render } from "../../test-utils";
 
 describe("EdgeContent", () => {
   const defaultProps = {

--- a/__tests__/components/flow/panel-content.test.tsx
+++ b/__tests__/components/flow/panel-content.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { ContributionPanelContent } from "../../../components/flow/contribution-panel";
 import { PanelContent } from "../../../components/flow/flow-panel";
+import { render } from "../../test-utils";
 
 describe("PanelContent", () => {
   const defaultProps = {

--- a/__tests__/components/mermaid/editable-mermaid-highlight.test.tsx
+++ b/__tests__/components/mermaid/editable-mermaid-highlight.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { EditableMermaidHighlight } from "../../../components/mermaid/editable-mermaid-highlight";
+import { render } from "../../test-utils";
 
 // PrismJSのモック
 vi.mock("prismjs", () => ({

--- a/__tests__/components/node/node-content.test.tsx
+++ b/__tests__/components/node/node-content.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { NodeContent } from "../../../components/node/editable-node";
 import { SHAPE_OPTIONS } from "../../../components/types/types";
+import { render } from "../../test-utils";
 
 describe("NodeContent", () => {
   const defaultProps = {

--- a/__tests__/components/node/shape-selector.test.tsx
+++ b/__tests__/components/node/shape-selector.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { ShapeSelector } from "../../../components/node/shape-selector";
 import { MermaidShapeType, SHAPE_OPTIONS } from "../../../components/types/types";
+import { render } from "../../test-utils";
 
 describe("ShapeSelector", () => {
   const defaultProps = {

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,1 +1,31 @@
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
+
+// matchMediaのモック
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// ResizeObserverのモック
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// IntersectionObserverのモック
+global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));

--- a/__tests__/test-utils.tsx
+++ b/__tests__/test-utils.tsx
@@ -1,0 +1,70 @@
+import type {
+  RenderHookOptions as OriginalRenderHookOptions,
+  RenderOptions as OriginalRenderOptions,
+  Queries,
+  queries,
+} from "@testing-library/react";
+import { render as originalRender, renderHook as originalRenderHook } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import type { UIProviderProps } from "@yamada-ui/react";
+import { UIProvider } from "@yamada-ui/react";
+import type { PropsWithChildren, ReactNode } from "react";
+import type { Container } from "react-dom/client";
+import "@testing-library/jest-dom/vitest";
+
+export interface RenderOptions extends OriginalRenderOptions {
+  withProvider?: boolean;
+  providerProps?: Omit<UIProviderProps, "children">;
+}
+
+export interface RenderReturn extends ReturnType<typeof originalRender> {
+  user: ReturnType<typeof userEvent.setup>;
+}
+
+export function render(
+  ui: ReactNode,
+  { withProvider = true, providerProps, ...options }: RenderOptions = {}
+): RenderReturn {
+  const user = userEvent.setup();
+
+  if (withProvider)
+    options.wrapper ??= (props: PropsWithChildren) => (
+      <UIProvider {...providerProps}>{props.children}</UIProvider>
+    );
+
+  const result = originalRender(ui, options);
+
+  return { user, ...result };
+}
+
+export interface RenderHookOptions<
+  Y,
+  M extends Queries = typeof queries,
+  D extends Container | Document | Element = HTMLElement,
+  H extends Container | Document | Element = D,
+> extends OriginalRenderHookOptions<Y, M, D, H> {
+  withProvider?: boolean;
+  providerProps?: Omit<UIProviderProps, "children">;
+}
+
+export function renderHook<
+  Y,
+  M,
+  D extends Queries = typeof queries,
+  H extends Container | Document | Element = HTMLElement,
+  R extends Container | Document | Element = H,
+>(
+  renderFn: (props: M) => Y,
+  { withProvider = true, providerProps, ...options }: RenderHookOptions<M, D, H, R> = {}
+) {
+  if (withProvider)
+    options.wrapper ??= (props: PropsWithChildren) => (
+      <UIProvider {...providerProps}>{props.children}</UIProvider>
+    );
+
+  return originalRenderHook<Y, M, D, H, R>(renderFn, options);
+}
+
+// Re-export everything from @testing-library/react
+export * from "@testing-library/react";
+export { userEvent } from "@testing-library/user-event";


### PR DESCRIPTION
テストでYamada UIコンポーネントを正しく動作させるためのテストユーティリティを改善しました。

主な変更:
- カスタムテストユーティリティの作成（UIProviderの自動ラップ）
- matchMedia、ResizeObserver等のモック追加
- 全テストファイルでカスタムrenderを使用
- テストユーティリティの使用方法ドキュメント追加

解決した問題:
- window.matchMedia is not function エラー
- Yamada UIテーマの適用問題
- テストの安定性向上

全14のテストが正常に動作することを確認済み。