### PR TITLE
feat: implement cyclic edge label positioning system

### DIFF
--- a/__tests__/utils/edge-layout.test.ts
+++ b/__tests__/utils/edge-layout.test.ts
@@ -97,6 +97,21 @@ describe("edge-layout utility functions", () => {
       expect(offset.offsetX).toBe(0);
       expect(offset.offsetY).toBe(0);
     });
+
+    test("セルフループ（自己参照エッジ）の処理", () => {
+      const selfLoopEdges = [
+        { id: "self1", source: "A", target: "A" },
+        { id: "self2", source: "A", target: "A" },
+      ];
+
+      const offset1 = calculateEdgeOffset(selfLoopEdges[0], selfLoopEdges);
+      const offset2 = calculateEdgeOffset(selfLoopEdges[1], selfLoopEdges);
+
+      // セルフループは円形パターンで配置される
+      expect(offset1.offsetX !== 0 || offset1.offsetY !== 0).toBe(true);
+      expect(offset2.offsetX !== 0 || offset2.offsetY !== 0).toBe(true);
+      expect(offset1).not.toEqual(offset2);
+    });
   });
 
   describe("adjustEdgeLabelPosition", () => {

--- a/__tests__/utils/edge-layout.test.ts
+++ b/__tests__/utils/edge-layout.test.ts
@@ -1,0 +1,195 @@
+import type { Edge } from "@xyflow/react";
+import { describe, test, expect } from "vitest";
+import {
+  detectCyclicEdges,
+  calculateEdgeOffset,
+  getCyclicEdgeStyle,
+  adjustEdgeLabelPosition,
+} from "../../utils/edge-layout";
+
+describe("edge-layout utility functions", () => {
+  const mockEdges: Edge[] = [
+    { id: "e1", source: "A", target: "B" },
+    { id: "e2", source: "B", target: "A" }, // 循環参照
+    { id: "e3", source: "C", target: "D" },
+    { id: "e4", source: "A", target: "C" }, // 通常のエッジ
+  ] as Edge[];
+
+  describe("detectCyclicEdges", () => {
+    test("循環参照を正しく検出する", () => {
+      const cyclicGroups = detectCyclicEdges(mockEdges);
+
+      expect(cyclicGroups.size).toBe(1);
+      expect(cyclicGroups.has("A-B")).toBe(true);
+
+      const cyclicEdges = cyclicGroups.get("A-B");
+      expect(cyclicEdges).toHaveLength(2);
+      expect(cyclicEdges?.some((e: Edge) => e.id === "e1")).toBe(true);
+      expect(cyclicEdges?.some((e: Edge) => e.id === "e2")).toBe(true);
+    });
+
+    test("循環参照でないエッジは検出しない", () => {
+      const nonCyclicEdges: Edge[] = [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "B", target: "C" },
+      ] as Edge[];
+
+      const cyclicGroups = detectCyclicEdges(nonCyclicEdges);
+      expect(cyclicGroups.size).toBe(0);
+    });
+
+    test("空のエッジ配列では循環参照なし", () => {
+      const cyclicGroups = detectCyclicEdges([]);
+      expect(cyclicGroups.size).toBe(0);
+    });
+
+    test("複数の循環参照グループを正しく処理する", () => {
+      const multiCyclicEdges: Edge[] = [
+        { id: "e1", source: "A", target: "B" }, // A-B循環
+        { id: "e2", source: "B", target: "A" }, // A-B循環
+        { id: "e3", source: "C", target: "D" },
+        { id: "e4", source: "D", target: "C" }, // C-D循環
+      ] as Edge[];
+
+      const cyclicGroups = detectCyclicEdges(multiCyclicEdges);
+      expect(cyclicGroups.size).toBe(2);
+      expect(cyclicGroups.has("A-B")).toBe(true);
+      expect(cyclicGroups.has("C-D")).toBe(true);
+    });
+  });
+
+  describe("calculateEdgeOffset", () => {
+    test("循環参照エッジにオフセットを適用する", () => {
+      const edge1 = mockEdges[0]; // A -> B
+      const edge2 = mockEdges[1]; // B -> A
+
+      const offset1 = calculateEdgeOffset(edge1, mockEdges);
+      const offset2 = calculateEdgeOffset(edge2, mockEdges);
+
+      // 両方のエッジが異なるオフセットを持つ
+      expect(offset1.offsetX !== 0 || offset1.offsetY !== 0).toBe(true);
+      expect(offset2.offsetX !== 0 || offset2.offsetY !== 0).toBe(true);
+      expect(offset1).not.toEqual(offset2);
+    });
+
+    test("循環参照でないエッジはオフセットなし", () => {
+      const normalEdge = mockEdges[2]; // C -> D
+      const offset = calculateEdgeOffset(normalEdge, mockEdges);
+
+      expect(offset.offsetX).toBe(0);
+      expect(offset.offsetY).toBe(0);
+    });
+
+    test("カスタムオフセット距離を適用する", () => {
+      const edge = mockEdges[0];
+      const customDistance = 50;
+      const offset = calculateEdgeOffset(edge, mockEdges, customDistance);
+
+      // カスタム距離を使ったオフセットが適用される
+      expect(Math.abs(offset.offsetX) <= customDistance * 2).toBe(true);
+      expect(Math.abs(offset.offsetY) <= customDistance * 2).toBe(true);
+    });
+
+    test("空のエッジ配列では全てオフセットなし", () => {
+      const edge = mockEdges[0];
+      const offset = calculateEdgeOffset(edge, []);
+
+      expect(offset.offsetX).toBe(0);
+      expect(offset.offsetY).toBe(0);
+    });
+  });
+
+  describe("adjustEdgeLabelPosition", () => {
+    test("循環参照エッジのラベル位置を調整する", () => {
+      const currentEdge = { source: "A", target: "B" };
+      const originalX = 100;
+      const originalY = 50;
+
+      const { adjustedX, adjustedY } = adjustEdgeLabelPosition(
+        currentEdge,
+        originalX,
+        originalY,
+        mockEdges,
+        []
+      );
+
+      // 位置が調整される（オリジナルと異なる）
+      expect(adjustedX !== originalX || adjustedY !== originalY).toBe(true);
+    });
+
+    test("循環参照でないエッジは位置調整なし", () => {
+      const currentEdge = { source: "C", target: "D" };
+      const originalX = 100;
+      const originalY = 50;
+
+      const { adjustedX, adjustedY } = adjustEdgeLabelPosition(
+        currentEdge,
+        originalX,
+        originalY,
+        mockEdges,
+        []
+      );
+
+      // 位置は変更されない
+      expect(adjustedX).toBe(originalX);
+      expect(adjustedY).toBe(originalY);
+    });
+
+    test("存在しないエッジの場合は位置調整なし", () => {
+      const currentEdge = { source: "X", target: "Y" };
+      const originalX = 100;
+      const originalY = 50;
+
+      const { adjustedX, adjustedY } = adjustEdgeLabelPosition(
+        currentEdge,
+        originalX,
+        originalY,
+        mockEdges,
+        []
+      );
+
+      // 位置は変更されない
+      expect(adjustedX).toBe(originalX);
+      expect(adjustedY).toBe(originalY);
+    });
+  });
+
+  describe("getCyclicEdgeStyle", () => {
+    test("循環参照エッジにスタイルを適用する（スタイリング有効時）", () => {
+      const currentEdge = { source: "A", target: "B" };
+      const style = getCyclicEdgeStyle(currentEdge, mockEdges, true);
+
+      expect(style).toHaveProperty("stroke");
+      expect(style).toHaveProperty("strokeOpacity");
+      expect(style).toHaveProperty("strokeWidth");
+    });
+
+    test("循環参照エッジでもスタイリング無効時はデフォルトスタイル", () => {
+      const currentEdge = { source: "A", target: "B" };
+      const style = getCyclicEdgeStyle(currentEdge, mockEdges, false);
+
+      expect(style).toEqual({});
+    });
+
+    test("循環参照でないエッジはデフォルトスタイル", () => {
+      const normalEdge = { source: "C", target: "D" };
+      const style = getCyclicEdgeStyle(normalEdge, mockEdges, true);
+
+      expect(style).toEqual({});
+    });
+
+    test("空のエッジ配列では全てデフォルトスタイル", () => {
+      const currentEdge = { source: "A", target: "B" };
+      const style = getCyclicEdgeStyle(currentEdge, [], true);
+
+      expect(style).toEqual({});
+    });
+
+    test("存在しないエッジはデフォルトスタイル", () => {
+      const currentEdge = { source: "X", target: "Y" };
+      const style = getCyclicEdgeStyle(currentEdge, mockEdges, true);
+
+      expect(style).toEqual({});
+    });
+  });
+});

--- a/components/flow/editable-edge.tsx
+++ b/components/flow/editable-edge.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import { BaseEdge, EdgeLabelRenderer, EdgeProps, getBezierPath } from "@xyflow/react";
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  EdgeProps,
+  getBezierPath,
+  useReactFlow,
+  Edge,
+} from "@xyflow/react";
 import { XIcon } from "@yamada-ui/lucide";
 import { Input, Box, IconButton, HStack } from "@yamada-ui/react";
 import { useState, useRef, useEffect } from "react";
+import { adjustEdgeLabelPosition, getCyclicEdgeStyle } from "../../utils/edge-layout";
 import { getArrowTypeSymbol } from "../../utils/mermaid";
 import { MermaidArrowType } from "../types/types";
 import { ArrowTypeSelector } from "./arrow-type-selector";
@@ -15,6 +23,7 @@ interface EditableEdgeProps extends EdgeProps {
     onLabelChange?: (edgeId: string, newLabel: string) => void;
     onArrowTypeChange?: (edgeId: string, arrowType: MermaidArrowType) => void;
     onDelete?: (edgeId: string) => void;
+    allEdges?: Edge[]; // 全エッジの情報（循環参照検出用）
   };
 }
 
@@ -165,7 +174,15 @@ export function EditableEdge({
   targetPosition,
   data,
   markerEnd,
+  source,
+  target,
 }: EditableEdgeProps) {
+  const { getEdges, getNodes } = useReactFlow();
+  const allEdges = getEdges();
+  const allNodes = getNodes();
+
+  const currentEdge = { id, source, target };
+
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
@@ -175,11 +192,24 @@ export function EditableEdge({
     targetPosition,
   });
 
+  // 循環参照対応のラベル位置調整
+  const { adjustedX, adjustedY } = adjustEdgeLabelPosition(
+    currentEdge,
+    labelX,
+    labelY,
+    allEdges,
+    allNodes
+  );
+
+  // 循環参照対応のエッジスタイル（オプション）
+  // ラベル位置調整のみにしたい場合は enableStyling: false にする
+  const cyclicStyle = getCyclicEdgeStyle(currentEdge, allEdges, false); // ラベル位置のみ
+
   return (
     <>
-      <BaseEdge path={edgePath} markerEnd={markerEnd} />
+      <BaseEdge path={edgePath} markerEnd={markerEnd} style={cyclicStyle} />
       <EdgeLabelRenderer>
-        <EdgeContent id={id} labelX={labelX} labelY={labelY} data={data} />
+        <EdgeContent id={id} labelX={adjustedX} labelY={adjustedY} data={data} />
       </EdgeLabelRenderer>
     </>
   );

--- a/components/flow/editable-edge.tsx
+++ b/components/flow/editable-edge.tsx
@@ -24,6 +24,7 @@ interface EditableEdgeProps extends EdgeProps {
     onArrowTypeChange?: (edgeId: string, arrowType: MermaidArrowType) => void;
     onDelete?: (edgeId: string) => void;
     allEdges?: Edge[]; // 全エッジの情報（循環参照検出用）
+    enableCyclicEdgeStyling?: boolean; // 循環参照エッジのスタイリングを有効にするか
   };
 }
 
@@ -202,8 +203,12 @@ export function EditableEdge({
   );
 
   // 循環参照対応のエッジスタイル（オプション）
-  // ラベル位置調整のみにしたい場合は enableStyling: false にする
-  const cyclicStyle = getCyclicEdgeStyle(currentEdge, allEdges, false); // ラベル位置のみ
+  // ラベル位置調整のみにしたい場合は enableCyclicEdgeStyling: false にする
+  const cyclicStyle = getCyclicEdgeStyle(
+    currentEdge,
+    allEdges,
+    data?.enableCyclicEdgeStyling ?? false
+  ); // ラベル位置のみ
 
   return (
     <>

--- a/components/flow/flow-editor.tsx
+++ b/components/flow/flow-editor.tsx
@@ -446,7 +446,6 @@ export function FlowEditor() {
     [
       setNodes,
       setEdges,
-      nodeId,
       handleLabelChange,
       handleVariableNameChange,
       handleShapeTypeChange,

--- a/components/mermaid/import-modal.tsx
+++ b/components/mermaid/import-modal.tsx
@@ -54,9 +54,8 @@ export function ImportModal({ open, onClose, onImport }: ImportModalProps) {
       onImport(parsedData);
       setMermaidCode("");
       onClose();
-    } catch (err) {
+    } catch {
       setError("Mermaidコードの解析中にエラーが発生しました");
-      console.error("Import error:", err);
     } finally {
       setIsLoading(false);
     }

--- a/utils/edge-layout.ts
+++ b/utils/edge-layout.ts
@@ -1,0 +1,128 @@
+import { Edge, Node } from "@xyflow/react";
+
+/**
+ * 循環参照エッジを検出する
+ */
+export function detectCyclicEdges(edges: Edge[]): Map<string, Edge[]> {
+  const cyclicGroups = new Map<string, Edge[]>();
+
+  // ノード間の接続をマップ化
+  const connections = new Map<string, Set<string>>();
+
+  edges.forEach((edge) => {
+    if (!connections.has(edge.source)) {
+      connections.set(edge.source, new Set());
+    }
+    connections.get(edge.source)?.add(edge.target);
+  });
+
+  // 循環参照を検出
+  edges.forEach((edge) => {
+    const { source, target } = edge;
+    const reverseExists = connections.get(target)?.has(source);
+
+    if (reverseExists) {
+      // 循環参照グループのキーを一意にする（小さい方を先に）
+      const groupKey = source < target ? `${source}-${target}` : `${target}-${source}`;
+
+      if (!cyclicGroups.has(groupKey)) {
+        cyclicGroups.set(groupKey, []);
+      }
+      cyclicGroups.get(groupKey)?.push(edge);
+    }
+  });
+
+  return cyclicGroups;
+}
+
+/**
+ * エッジのオフセットを計算する（循環参照対応）
+ */
+export function calculateEdgeOffset(
+  edge: Edge,
+  allEdges: Edge[],
+  offsetDistance: number = 20
+): { offsetX: number; offsetY: number } {
+  const cyclicGroups = detectCyclicEdges(allEdges);
+
+  // この エッジが循環参照グループに属するかチェック
+  for (const [, groupEdges] of Array.from(cyclicGroups.entries())) {
+    const edgeInGroup = groupEdges.find((e: Edge) => e.id === edge.id);
+    if (edgeInGroup) {
+      // グループ内でのエッジのインデックスを取得
+      const edgeIndex = groupEdges.indexOf(edgeInGroup);
+
+      // オフセットを計算（上下または左右に分散）
+      const offsetMultiplier = edgeIndex % 2 === 0 ? 1 : -1;
+      const offsetAmount = Math.floor(edgeIndex / 2 + 1) * offsetDistance * offsetMultiplier;
+
+      // エッジの方向に応じてオフセット方向を決定
+      const dx =
+        edgeInGroup.target === edgeInGroup.source
+          ? 0
+          : parseInt(edgeInGroup.target) > parseInt(edgeInGroup.source)
+            ? offsetAmount
+            : -offsetAmount;
+      const dy = offsetAmount;
+
+      return { offsetX: dx, offsetY: dy };
+    }
+  }
+
+  // 循環参照でない場合はオフセットなし
+  return { offsetX: 0, offsetY: 0 };
+}
+
+/**
+ * エッジラベルの位置を調整する（重複回避）
+ */
+export const adjustEdgeLabelPosition = (
+  currentEdge: { source: string; target: string },
+  originalX: number,
+  originalY: number,
+  allEdges: Edge[],
+  _nodes: Node[]
+): { adjustedX: number; adjustedY: number } => {
+  // currentEdgeをEdge型に変換
+  const edgeAsEdge = allEdges.find(
+    (e) => e.source === currentEdge.source && e.target === currentEdge.target
+  );
+  if (!edgeAsEdge) {
+    return { adjustedX: originalX, adjustedY: originalY };
+  }
+
+  const { offsetX, offsetY } = calculateEdgeOffset(edgeAsEdge, allEdges);
+
+  return {
+    adjustedX: originalX + offsetX,
+    adjustedY: originalY + offsetY,
+  };
+};
+
+/**
+ * 循環参照エッジのスタイルを取得する
+ */
+export function getCyclicEdgeStyle(
+  currentEdge: { source: string; target: string },
+  allEdges: Edge[],
+  enableStyling: boolean = false
+): React.CSSProperties {
+  const cyclicGroups = detectCyclicEdges(allEdges);
+
+  // 循環参照グループに属するかチェック
+  for (const [, groupEdges] of Array.from(cyclicGroups.entries())) {
+    const isInCyclicGroup = groupEdges.some(
+      (edge: Edge) => edge.source === currentEdge.source && edge.target === currentEdge.target
+    );
+
+    if (isInCyclicGroup && enableStyling) {
+      return {
+        stroke: "#ff6b6b",
+        strokeOpacity: 0.8,
+        strokeWidth: 2,
+      };
+    }
+  }
+
+  return {};
+}

--- a/utils/edge-layout.ts
+++ b/utils/edge-layout.ts
@@ -56,16 +56,25 @@ export function calculateEdgeOffset(
       const offsetMultiplier = edgeIndex % 2 === 0 ? 1 : -1;
       const offsetAmount = Math.floor(edgeIndex / 2 + 1) * offsetDistance * offsetMultiplier;
 
-      // エッジの方向に応じてオフセット方向を決定
-      const dx =
-        edgeInGroup.target === edgeInGroup.source
-          ? 0
-          : edgeInGroup.target.localeCompare(edgeInGroup.source) > 0
-            ? offsetAmount
-            : -offsetAmount;
-      const dy = offsetAmount;
-
-      return { offsetX: dx, offsetY: dy };
+      // Handle self-loops differently: offset in a circular pattern around the node
+      if (edgeInGroup.target === edgeInGroup.source) {
+        // Get all self-loops for this node in the group
+        const selfLoops = groupEdges.filter(
+          (e) => e.source === edgeInGroup.source && e.target === edgeInGroup.target
+        );
+        const selfLoopIndex = selfLoops.findIndex((e) => e.id === edgeInGroup.id);
+        // Distribute self-loops around the node in a circle
+        const angle = ((2 * Math.PI) / Math.max(selfLoops.length, 1)) * selfLoopIndex;
+        const radius = offsetDistance * (1 + selfLoopIndex); // Increase radius for each self-loop
+        const dx = Math.cos(angle) * radius;
+        const dy = Math.sin(angle) * radius;
+        return { offsetX: dx, offsetY: dy };
+      } else {
+        const dx =
+          String(edgeInGroup.target) > String(edgeInGroup.source) ? offsetAmount : -offsetAmount;
+        const dy = offsetAmount;
+        return { offsetX: dx, offsetY: dy };
+      }
     }
   }
 

--- a/utils/edge-layout.ts
+++ b/utils/edge-layout.ts
@@ -45,7 +45,7 @@ export function calculateEdgeOffset(
 ): { offsetX: number; offsetY: number } {
   const cyclicGroups = detectCyclicEdges(allEdges);
 
-  // この エッジが循環参照グループに属するかチェック
+  // このエッジが循環参照グループに属するかチェック
   for (const [, groupEdges] of Array.from(cyclicGroups.entries())) {
     const edgeInGroup = groupEdges.find((e: Edge) => e.id === edge.id);
     if (edgeInGroup) {
@@ -60,7 +60,7 @@ export function calculateEdgeOffset(
       const dx =
         edgeInGroup.target === edgeInGroup.source
           ? 0
-          : parseInt(edgeInGroup.target) > parseInt(edgeInGroup.source)
+          : edgeInGroup.target.localeCompare(edgeInGroup.source) > 0
             ? offsetAmount
             : -offsetAmount;
       const dy = offsetAmount;


### PR DESCRIPTION
## 概要
A→B、B→Aのような循環エッジでラベルが重複して編集できなくなる問題を解決するラベル位置調整システムを実装しました。

## 変更内容

### 新機能
- **循環エッジ検出システム**: 双方向の接続を自動検出
- **ラベル位置調整**: 循環エッジのラベルを自動的にオフセット配置
- **オプション視覚スタイリング**: 循環エッジの色分け（無効化可能）

### 技術的詳細
- `utils/edge-layout.ts`: 循環エッジ検出・ラベル位置計算ユーティリティ
- `detectCyclicEdges()`: A→B, B→A形式の循環参照を検出
- `adjustEdgeLabelPosition()`: ラベル重複を防ぐ位置調整
- `getCyclicEdgeStyle()`: オプションの視覚的区別スタイル

### テスト
- **16個のテストケース**でエッジレイアウト機能を網羅的にカバー
- 循環参照検出、位置調整、スタイリングの各機能をテスト
- エラーケース（存在しないエッジ、空配列）も含む

### コード品質
- ESLintエラー修正: `any`型を適切な`Edge[]`/`Node[]`型に置換
- 未使用変数の除去
- useCallbackの依存関係最適化

## UX改善
- **問題**: A→B, B→Aの循環エッジでラベルが重なり編集不可
- **解決**: ラベルを自動的にオフセット配置して編集可能に
- **設計思想**: 視覚的な明瞭さを保ちつつ実用性を重視（デフォルトで色変更なし）

## テスト結果
✅ 全241個のテストが通過  
✅ ESLintエラーなし  
✅ 型安全性確保  

## 動作確認
循環エッジを作成してラベル編集が正常に動作することを確認済み。