### PR TITLE
refactor: use shared install action in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,22 +18,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install node_modules
-        run: |
-          node --version
-          pnpm install
+      - name: Setup Node.js and PNPM
+        uses: ./.github/actions/install
 
       - name: Build
         run: |


### PR DESCRIPTION
## 📦 Refactor Deploy Workflow

### 概要
Deploy workflowでも共通のinstallアクションを使用するようにリファクタリング

### 変更内容
- ✅ を使用して重複コードを削除
- ✅ CI workflow()との一貫性を保持
- ✅ Node.js/pnpmバージョン管理を一元化

### Before/After

#### Before (16 lines)
```yaml
- name: Setup PNPM
  uses: pnpm/action-setup@v4
  with:
    version: 9
- name: Setup Node.js
  uses: actions/setup-node@v4
  with:
    node-version: "20"
    registry-url: "https://registry.npmjs.org"
    cache: "pnpm"
- name: Install node_modules
  run: |
    node --version
    pnpm install
```

#### After (2 lines)
```yaml
- name: Setup Node.js and PNPM
  uses: ./.github/actions/install
```

### メリット
1. **DRY原則**: コード重複の排除（14行削減）
2. **一貫性**: CI/CDワークフローで同じセットアップ
3. **メンテナンス性**: バージョン変更が1箇所で完結
4. **軽量キャッシュ**: deploy時もキャッシュ効果を享受

### テスト
- [ ] Deploy workflowが正常に動作すること
- [ ] ビルド成果物が期待通りに生成されること