### PR TITLE
モバイル時のモーダルヘッダーのレイアウト修正

### DIFF
--- a/components/mermaid/download-modal.tsx
+++ b/components/mermaid/download-modal.tsx
@@ -71,13 +71,19 @@ export function DownloadModal({ open, onClose, flowData }: DownloadModalProps) {
   return (
     <Modal open={open} onClose={onClose} size="2xl">
       <ModalHeader>
-        <HStack justify="space-between">
+        <HStack
+          justify={{ base: "space-between", md: "flex-start" }}
+          display={{ base: "flex", md: "inline-flex" }}
+          flexWrap="wrap"
+          alignItems="center"
+        >
           <Text>生成されたMermaidコード</Text>
           <Button
             startIcon={<DownloadIcon />}
             colorScheme="blue"
             size="sm"
             onClick={downloadMermaidCode}
+            ml={{ base: 0, md: "auto" }}
           >
             ダウンロード
           </Button>


### PR DESCRIPTION
| 修正前 | 修正後 |
|--------|--------|
| <img width="194" height="426" alt="image" src="https://github.com/user-attachments/assets/4cdbc204-edb8-44a5-8740-a5a7d0adcbdd" /> | <img width="195" height="422" alt="image" src="https://github.com/user-attachments/assets/86535390-e1fa-4e6c-9825-16d91c606b6e" /> | 