### PR TITLE
feat: ER図テーブルのアクセシビリティ改善とテスト安定化

### DIFF
--- a/__tests__/components/er/er-table-content.test.tsx
+++ b/__tests__/components/er/er-table-content.test.tsx
@@ -1,0 +1,134 @@
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { useState, useEffect, ReactNode, MutableRefObject } from "react";
+import { describe, test, expect } from "vitest";
+import { ERTableContent, ERColumn } from "../../../components/er/ERTableContent";
+import { render } from "../../test-utils";
+
+const defaultColumns: ERColumn[] = [
+  { name: "id", type: "int", pk: true, nn: true, defaultValue: "auto_increment" },
+  { name: "name", type: "varchar(255)", pk: false, nn: false, defaultValue: "" },
+];
+
+// テスト用ラッパー（テスト本体でstateを直接参照できる形）
+function StateWrapper({
+  initialName = "ユーザー",
+  initialColumns = defaultColumns,
+  children,
+}: {
+  initialName?: string;
+  initialColumns?: ERColumn[];
+  children: (props: {
+    name: string;
+    setName: (v: string) => void;
+    columns: ERColumn[];
+    setColumns: (v: ERColumn[]) => void;
+  }) => ReactNode;
+}) {
+  const [name, setName] = useState(initialName);
+  const [columns, setColumns] = useState(initialColumns);
+  return <>{children({ name, setName, columns, setColumns })}</>;
+}
+
+describe("ERTableContent", () => {
+  test("名前書き換えができる", () => {
+    render(
+      <StateWrapper>
+        {({ name, setName, columns }) => (
+          <ERTableContent
+            name={name}
+            columns={columns}
+            onNameChange={setName}
+            onColumnsChange={() => {}}
+          />
+        )}
+      </StateWrapper>
+    );
+    const input = screen.getByDisplayValue("ユーザー");
+    fireEvent.change(input, { target: { value: "テーブルA" } });
+    expect(input).toHaveValue("テーブルA");
+  });
+
+  test("行追加ができる", async () => {
+    let latestColumns: ERColumn[] = [];
+    render(
+      <StateWrapper>
+        {({ name, columns, setColumns }) => {
+          latestColumns = columns;
+          return (
+            <ERTableContent
+              name={name}
+              columns={columns}
+              onNameChange={() => {}}
+              onColumnsChange={setColumns}
+            />
+          );
+        }}
+      </StateWrapper>
+    );
+    const addBtn = screen.getByRole("button", { name: "カラム追加" });
+    fireEvent.click(addBtn);
+    await waitFor(() => {
+      expect(latestColumns.length).toBe(3);
+    });
+  });
+
+  test("行削除ができる", () => {
+    render(
+      <StateWrapper>
+        {({ name, columns, setColumns }) => (
+          <ERTableContent
+            name={name}
+            columns={columns}
+            onNameChange={() => {}}
+            onColumnsChange={setColumns}
+          />
+        )}
+      </StateWrapper>
+    );
+    const delBtns = screen.getAllByRole("button", { name: "削除" });
+    fireEvent.click(delBtns[0]);
+    // 削除後のカラム数を確認
+    expect(screen.getAllByRole("row").length).toBe(2); // ヘッダー+1行
+  });
+
+  test("セル編集（テキスト・チェックボックス）ができる", async () => {
+    function TestComponent({ columnsRef }: { columnsRef: MutableRefObject<ERColumn[]> }) {
+      const [columns, setColumns] = useState(defaultColumns);
+      useEffect(() => {
+        columnsRef.current = columns;
+      }, [columns]);
+      return (
+        <ERTableContent
+          name="テーブル"
+          columns={columns}
+          onNameChange={() => {}}
+          onColumnsChange={setColumns}
+        />
+      );
+    }
+    const columnsRef = { current: defaultColumns } as MutableRefObject<ERColumn[]>;
+    render(<TestComponent columnsRef={columnsRef} />);
+    // nameカラム編集
+    const nameInputs = screen.getAllByDisplayValue(/id|name/);
+    fireEvent.change(nameInputs[1], { target: { value: "名前" } });
+    fireEvent.blur(nameInputs[1]);
+    expect(nameInputs[1]).toHaveValue("名前");
+    // typeカラム編集
+    const typeInputs = screen.getAllByDisplayValue(/int|varchar/);
+    fireEvent.change(typeInputs[1], { target: { value: "text" } });
+    fireEvent.blur(typeInputs[1]);
+    expect(typeInputs[1]).toHaveValue("text");
+    // pkチェック
+    const pkChecks = screen.getAllByRole("checkbox", { name: "PK" });
+    fireEvent.click(pkChecks[1]);
+    expect(pkChecks[1]).toBeChecked();
+    const nnChecks = screen.getAllByRole("checkbox", { name: "NN" });
+    fireEvent.click(nnChecks[1]);
+    expect(nnChecks[1]).toBeChecked();
+    // defaultValue編集
+    const defaultInputs = screen.getAllByDisplayValue("auto_increment");
+    fireEvent.change(defaultInputs[0], { target: { value: "hoge" } });
+    fireEvent.blur(defaultInputs[0]);
+    expect(defaultInputs[0]).toHaveValue("hoge");
+  });
+});

--- a/__tests__/components/mermaid/download-modal.test.tsx
+++ b/__tests__/components/mermaid/download-modal.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react";
-import React from "react";
+import { HTMLAttributes } from "react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import type { FlowData } from "../../../components/flow/flow-helpers";
 import { DownloadModal } from "../../../components/mermaid/download-modal";
@@ -31,10 +31,7 @@ vi.mock("../../../components/mermaid/mermaid-highlight", () => ({
 
 // CopyButtonのモック
 vi.mock("../../../components/ui/copy-button", () => ({
-  CopyButton: ({
-    value,
-    ...props
-  }: { value: string } & React.HTMLAttributes<HTMLButtonElement>) => (
+  CopyButton: ({ value, ...props }: { value: string } & HTMLAttributes<HTMLButtonElement>) => (
     <button data-testid="copy-button" data-value={value} {...props}>
       コピー
     </button>

--- a/__tests__/components/mermaid/editable-mermaid-highlight.test.tsx
+++ b/__tests__/components/mermaid/editable-mermaid-highlight.test.tsx
@@ -1,4 +1,5 @@
 import { screen, fireEvent } from "@testing-library/react";
+import { ChangeEvent } from "react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import { EditableMermaidHighlight } from "../../../components/mermaid/editable-mermaid-highlight";
 import { render } from "../../test-utils";
@@ -27,7 +28,7 @@ vi.mock("react-simple-code-editor", () => ({
     placeholder?: string;
     highlight?: (value: string) => string;
   }) => {
-    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
       onValueChange(e.target.value);
     };
 

--- a/__tests__/components/mermaid/import-modal.test.tsx
+++ b/__tests__/components/mermaid/import-modal.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
-import React from "react";
+import { HTMLAttributes } from "react";
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import { ImportModal } from "../../../components/mermaid/import-modal";
 import type { MermaidShapeType, MermaidArrowType } from "../../../components/types/types";
@@ -27,7 +27,7 @@ vi.mock("../../../components/mermaid/editable-mermaid-highlight", () => ({
     onChange: (value: string) => void;
     placeholder: string;
     minHeight?: string;
-  } & React.HTMLAttributes<HTMLDivElement>) => (
+  } & HTMLAttributes<HTMLDivElement>) => (
     <div data-testid="editable-mermaid-highlight" style={{ minHeight }} {...props}>
       <textarea
         data-testid="mermaid-code-input"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { ReactNode } from "react";
 import { AppProviders } from "../components/providers";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -12,7 +13,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="ja">

--- a/components/editor/label-editor.tsx
+++ b/components/editor/label-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Text, Input } from "@yamada-ui/react";
+import { Text, Input, FC } from "@yamada-ui/react";
 import { ChangeEvent, KeyboardEvent } from "react";
 
 interface LabelEditorProps {
@@ -14,7 +14,7 @@ interface LabelEditorProps {
   onBlur: () => void;
 }
 
-export function LabelEditor({
+export const LabelEditor: FC<LabelEditorProps> = ({
   value,
   isEditing,
   onDoubleClick,
@@ -23,7 +23,7 @@ export function LabelEditor({
   onCompositionStart,
   onCompositionEnd,
   onBlur,
-}: LabelEditorProps) {
+}) => {
   return (
     <>
       {isEditing ? (
@@ -59,4 +59,4 @@ export function LabelEditor({
       )}
     </>
   );
-}
+};

--- a/components/editor/variable-name-editor.tsx
+++ b/components/editor/variable-name-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Input } from "@yamada-ui/react";
+import { Box, FC, Input } from "@yamada-ui/react";
 import { MouseEvent, ChangeEvent, KeyboardEvent } from "react";
 import { formatMermaidShape } from "../../utils/mermaid";
 import { MermaidShapeType } from "../types/types";
@@ -17,7 +17,7 @@ interface VariableNameEditorProps {
   onBlur: () => void;
 }
 
-export function VariableNameEditor({
+export const VariableNameEditor: FC<VariableNameEditorProps> = ({
   value,
   isEditing,
   shapeType,
@@ -27,7 +27,7 @@ export function VariableNameEditor({
   onCompositionStart,
   onCompositionEnd,
   onBlur,
-}: VariableNameEditorProps) {
+}) => {
   // formatMermaidShapeを使って形状記号付きの表示を取得
   const displayValue = formatMermaidShape(shapeType || "rectangle", value);
 
@@ -72,4 +72,4 @@ export function VariableNameEditor({
       )}
     </Box>
   );
-}
+};

--- a/components/er/ERTableNode.tsx
+++ b/components/er/ERTableNode.tsx
@@ -1,0 +1,21 @@
+import { Handle, Position } from "@xyflow/react";
+import { Box } from "@yamada-ui/react";
+import { ERColumn, ERTableContent } from "./ERTableContent";
+
+// ReactFlowノードラッパーとしてpropsをそのままContentに渡すだけ
+export type ERTableNodeProps = {
+  name: string;
+  columns: ERColumn[];
+  onNameChange: (name: string) => void;
+  onColumnsChange: (columns: ERColumn[]) => void;
+};
+
+export function ERTableNode(props: ERTableNodeProps) {
+  return (
+    <Box borderWidth={1} borderRadius="md" p={3} bg="white" minW="320px" boxShadow="md">
+      <ERTableContent {...props} />
+      <Handle type="target" position={Position.Top} />
+      <Handle type="source" position={Position.Bottom} />
+    </Box>
+  );
+}

--- a/components/flow/arrow-type-selector.tsx
+++ b/components/flow/arrow-type-selector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronDownIcon } from "@yamada-ui/lucide";
-import { Menu, MenuButton, MenuList, MenuItem, IconButton, Portal } from "@yamada-ui/react";
+import { Menu, MenuButton, MenuList, MenuItem, IconButton, Portal, FC } from "@yamada-ui/react";
 import { getArrowTypeDisplayName } from "../../utils/mermaid";
 import { MermaidArrowType, ARROW_TYPES } from "../types/types";
 
@@ -10,7 +10,10 @@ interface ArrowTypeSelectorProps {
   onArrowTypeChange: (arrowType: MermaidArrowType) => void;
 }
 
-export function ArrowTypeSelector({ currentArrowType, onArrowTypeChange }: ArrowTypeSelectorProps) {
+export const ArrowTypeSelector: FC<ArrowTypeSelectorProps> = ({
+  currentArrowType,
+  onArrowTypeChange,
+}) => {
   return (
     <Menu>
       <MenuButton
@@ -42,4 +45,4 @@ export function ArrowTypeSelector({ currentArrowType, onArrowTypeChange }: Arrow
       </Portal>
     </Menu>
   );
-}
+};

--- a/components/flow/editable-edge.tsx
+++ b/components/flow/editable-edge.tsx
@@ -10,7 +10,7 @@ import {
 } from "@xyflow/react";
 import { XIcon } from "@yamada-ui/lucide";
 import { Input, Box, IconButton, HStack } from "@yamada-ui/react";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, MouseEvent, KeyboardEvent } from "react";
 import { adjustEdgeLabelPosition, getCyclicEdgeStyle } from "../../utils/edge-layout";
 import { getArrowTypeSymbol } from "../../utils/mermaid";
 import { MermaidArrowType } from "../types/types";
@@ -48,7 +48,7 @@ export function EdgeContent({ id, labelX, labelY, data }: EdgeContentProps) {
     }
   }, [isEditing]);
 
-  const handleClick = (e: React.MouseEvent) => {
+  const handleClick = (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setIsEditing(true);
@@ -61,7 +61,7 @@ export function EdgeContent({ id, labelX, labelY, data }: EdgeContentProps) {
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Enter" && !isComposing) {
       handleSubmit();
     } else if (e.key === "Escape") {
@@ -88,7 +88,7 @@ export function EdgeContent({ id, labelX, labelY, data }: EdgeContentProps) {
     }
   };
 
-  const handleDelete = (e: React.MouseEvent) => {
+  const handleDelete = (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     if (data?.onDelete) {

--- a/components/flow/flow-panel.tsx
+++ b/components/flow/flow-panel.tsx
@@ -2,7 +2,7 @@
 
 import { Panel } from "@xyflow/react";
 import { PlusIcon, CodeIcon, UploadIcon } from "@yamada-ui/lucide";
-import { VStack, HStack, Text, Button, useDisclosure } from "@yamada-ui/react";
+import { VStack, HStack, Text, Button, useDisclosure, FC } from "@yamada-ui/react";
 import { ParsedMermaidData } from "../../utils/mermaid";
 import { ImportModal } from "../mermaid";
 
@@ -18,7 +18,7 @@ interface PanelContentProps {
   onImportMermaid: (data: ParsedMermaidData) => void;
 }
 
-export function FlowPanel({ onAddNode, onGenerateCode, onImportMermaid }: FlowPanelProps) {
+export const FlowPanel: FC<FlowPanelProps> = ({ onAddNode, onGenerateCode, onImportMermaid }) => {
   return (
     <Panel position="top-left">
       <PanelContent
@@ -28,9 +28,13 @@ export function FlowPanel({ onAddNode, onGenerateCode, onImportMermaid }: FlowPa
       />
     </Panel>
   );
-}
+};
 
-export function PanelContent({ onAddNode, onGenerateCode, onImportMermaid }: PanelContentProps) {
+export const PanelContent: FC<PanelContentProps> = ({
+  onAddNode,
+  onGenerateCode,
+  onImportMermaid,
+}) => {
   const { open, onOpen, onClose } = useDisclosure();
 
   return (
@@ -57,4 +61,4 @@ export function PanelContent({ onAddNode, onGenerateCode, onImportMermaid }: Pan
       <ImportModal open={open} onClose={onClose} onImport={onImportMermaid} />
     </VStack>
   );
-}
+};

--- a/components/mermaid/download-modal.tsx
+++ b/components/mermaid/download-modal.tsx
@@ -23,6 +23,7 @@ import {
   MenuItem,
   Component,
   IconProps,
+  FC,
 } from "@yamada-ui/react";
 import { useCallback, useState, useMemo } from "react";
 import { generateMermaidCode } from "../../utils/mermaid";
@@ -48,7 +49,7 @@ const graphType: GraphTypeWithArrow[] = [
   { type: "BT", arrow: ArrowUpIcon },
 ];
 
-export function DownloadModal({ open, onClose, flowData }: DownloadModalProps) {
+export const DownloadModal: FC<DownloadModalProps> = ({ open, onClose, flowData }) => {
   const [currentGraphType, setCurrentGraphType] = useState<GraphType>("TD");
 
   // 現在選択されている方向でMermaidコードを生成
@@ -116,4 +117,4 @@ export function DownloadModal({ open, onClose, flowData }: DownloadModalProps) {
       </ModalBody>
     </Modal>
   );
-}
+};

--- a/components/mermaid/editable-mermaid-highlight.tsx
+++ b/components/mermaid/editable-mermaid-highlight.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box } from "@yamada-ui/react";
+import { Box, FC } from "@yamada-ui/react";
 import { highlight, languages } from "prismjs";
 import Editor from "react-simple-code-editor";
 import "prismjs/themes/prism-dark.css";
@@ -14,13 +14,13 @@ interface EditableMermaidHighlightProps {
   fontSize?: string;
 }
 
-export function EditableMermaidHighlight({
+export const EditableMermaidHighlight: FC<EditableMermaidHighlightProps> = ({
   value,
   onChange,
   placeholder = "Mermaidコードを入力...",
   minHeight = "300px",
   fontSize = "14px",
-}: EditableMermaidHighlightProps) {
+}) => {
   const highlightCode = (code: string) => {
     try {
       // Now using Mermaid syntax highlighting with PrismJS
@@ -75,4 +75,4 @@ export function EditableMermaidHighlight({
       />
     </Box>
   );
-}
+};

--- a/components/mermaid/import-modal.tsx
+++ b/components/mermaid/import-modal.tsx
@@ -12,6 +12,7 @@ import {
   Alert,
   AlertIcon,
   AlertDescription,
+  FC,
 } from "@yamada-ui/react";
 import { useState } from "react";
 import { parseMermaidCode } from "../../utils/mermaid";
@@ -27,7 +28,7 @@ interface ImportModalProps {
 // ヘルプテキストの定数
 const HELP_TEXT = `💡 対応しているノード形状: 四角形[label], ダイヤモンド{label}, 円((label)), 六角形{{label}}, スタジアム([label]), 角丸(label)`;
 
-export function ImportModal({ open, onClose, onImport }: ImportModalProps) {
+export const ImportModal: FC<ImportModalProps> = ({ open, onClose, onImport }) => {
   const [mermaidCode, setMermaidCode] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -114,7 +115,7 @@ export function ImportModal({ open, onClose, onImport }: ImportModalProps) {
       </ModalFooter>
     </Modal>
   );
-}
+};
 
 const ErrorAlert = ({ message }: { message: string }) => (
   <Alert status="error">

--- a/components/mermaid/mermaid-highlight.tsx
+++ b/components/mermaid/mermaid-highlight.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box } from "@yamada-ui/react";
+import { Box, FC } from "@yamada-ui/react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 
@@ -11,12 +11,12 @@ interface MermaidHighlightProps {
   fontSize?: string;
 }
 
-export function MermaidHighlight({
+export const MermaidHighlight: FC<MermaidHighlightProps> = ({
   code,
   showLineNumbers = true,
   minHeight = "400px",
   fontSize = "14px",
-}: MermaidHighlightProps) {
+}) => {
   return (
     <Box w="full" borderRadius="md" overflow="hidden" border="1px solid" borderColor="border">
       <SyntaxHighlighter
@@ -33,4 +33,4 @@ export function MermaidHighlight({
       </SyntaxHighlighter>
     </Box>
   );
-}
+};

--- a/components/node/editable-node.tsx
+++ b/components/node/editable-node.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Handle, Position } from "@xyflow/react";
-import { Box } from "@yamada-ui/react";
+import { Box, FC } from "@yamada-ui/react";
 import { useState, useRef, MouseEvent, ChangeEvent, KeyboardEvent } from "react";
 import { VariableNameEditor, LabelEditor } from "../editor";
 import { UI_CONSTANTS, MermaidShapeType } from "../types/types";
@@ -20,7 +20,7 @@ interface EditableNodeProps {
   id: string;
 }
 
-export function EditableNode(props: EditableNodeProps) {
+export const EditableNode: FC<EditableNodeProps> = (props) => {
   return (
     <>
       <NodeContent {...props} />
@@ -28,9 +28,9 @@ export function EditableNode(props: EditableNodeProps) {
       <Handle type="source" position={Position.Bottom} />
     </>
   );
-}
+};
 
-export function NodeContent({ data, id }: EditableNodeProps) {
+export const NodeContent: FC<EditableNodeProps> = ({ data, id }) => {
   const [isEditingLabel, setIsEditingLabel] = useState(false);
   const [isEditingVariableName, setIsEditingVariableName] = useState(false);
   const [label, setLabel] = useState(data.label);
@@ -203,4 +203,4 @@ export function NodeContent({ data, id }: EditableNodeProps) {
       />
     </Box>
   );
-}
+};

--- a/components/providers/app-providers.tsx
+++ b/components/providers/app-providers.tsx
@@ -1,5 +1,5 @@
 import { ReactFlowProvider } from "@xyflow/react";
-import { UIProvider } from "@yamada-ui/react";
+import { FC, UIProvider } from "@yamada-ui/react";
 import type { ReactNode } from "react";
 import "@xyflow/react/dist/style.css";
 
@@ -7,10 +7,10 @@ interface AppProvidersProps {
   children: ReactNode;
 }
 
-export function AppProviders({ children }: AppProvidersProps) {
+export const AppProviders: FC<AppProvidersProps> = ({ children }) => {
   return (
     <UIProvider>
       <ReactFlowProvider>{children}</ReactFlowProvider>
     </UIProvider>
   );
-}
+};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build-storybook": "storybook build -o docs/storybook"
   },
   "dependencies": {
+    "@tanstack/react-table": "^8.21.3",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@xyflow/react": "^12.8.2",
     "@yamada-ui/lucide": "^1.10.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
@@ -1066,6 +1069,17 @@ packages:
 
   '@swc/helpers@0.5.2':
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5277,6 +5291,14 @@ snapshots:
   '@swc/helpers@0.5.2':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/react-table@8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/stories/components/er/er-table-content.stories.tsx
+++ b/stories/components/er/er-table-content.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta } from "@storybook/react-vite";
+import { useState } from "react";
+import { ERTableContent, ERColumn } from "../../../components/er/ERTableContent";
+
+const meta: Meta<typeof ERTableContent> = {
+  title: "components/er/ERTableContent",
+  component: ERTableContent,
+};
+export default meta;
+
+const initialColumns: ERColumn[] = [
+  { name: "id", type: "int", pk: true, nn: true, defaultValue: "auto_increment" },
+  { name: "name", type: "varchar(255)", pk: false, nn: false, defaultValue: "" },
+];
+
+export const Default = {
+  render: () => {
+    const [name, setName] = useState("ユーザー");
+    const [columns, setColumns] = useState(initialColumns);
+    return (
+      <ERTableContent
+        name={name}
+        columns={columns}
+        onNameChange={setName}
+        onColumnsChange={setColumns}
+      />
+    );
+  },
+};

--- a/utils/edge-layout.ts
+++ b/utils/edge-layout.ts
@@ -1,4 +1,5 @@
 import { Edge, Node } from "@xyflow/react";
+import { CSSProperties } from "react";
 
 /**
  * 循環参照エッジを検出する
@@ -130,7 +131,7 @@ export function getCyclicEdgeStyle(
   currentEdge: { source: string; target: string },
   allEdges: Edge[],
   enableStyling: boolean = false
-): React.CSSProperties {
+): CSSProperties {
   const cyclicGroups = detectCyclicEdges(allEdges);
 
   // 循環参照グループに属するかチェック


### PR DESCRIPTION
## 概要
- ERTableContentのPK/NNチェックボックスにaria-labelを追加し、テストでラベル指定取得が可能に
- テストコードもgetByRole("checkbox", { name: "PK" })等で安定して要素取得できるよう修正
- useEffectのcolumnsRef依存警告は実害がないため現状維持（必要ならeslint-disable-next-lineで抑制可）

## 背景・目的
- 複数テーブル生成時のid衝突を回避し、テストの信頼性・保守性を向上させるため
- 元イシュー: ER図テーブルのアクセシビリティ・テスト安定化

## 関連イシュー
- #（該当イシュー番号を後で追記してください）

ご確認よろしくお願いします。