### PR TITLE
fix: フローチャートのパネルコンテンツテストでアニメーション待機を修正

### DIFF
--- a/features/flowchart/__tests__/components/flow/panel-content.test.tsx
+++ b/features/flowchart/__tests__/components/flow/panel-content.test.tsx
@@ -159,8 +159,9 @@ describe("PanelContent", () => {
       // メニューを開く
       const menuButton = screen.getByRole("button", { name: "コントリビューションメニュー" });
       await user.click(menuButton);
-      // メニュー内のリンクを取得
-      const githubLink = screen.getByRole("menuitem", { name: "リポジトリを見る" });
+
+      // メニューのアニメーション完了を待つ
+      const githubLink = await screen.findByRole("menuitem", { name: "リポジトリを見る" });
       expect(githubLink).toHaveAttribute("rel", "noopener noreferrer");
     });
   });


### PR DESCRIPTION
## 変更内容

フローチャートのパネルコンテンツテストで断続的に発生していたテスト失敗を修正しました。

## 問題

- CI環境でときどき「GitHubリンクが適切な属性を持つ」テストが失敗していた
- Yamada UIのメニューコンポーネントのアニメーションが完了する前にテストが実行されていた
- メニューが `visibility: hidden` 状態でアクセシブルではないと判定されていた

## 修正内容

- `screen.getByRole()` を `screen.findByRole()` に変更
- メニューのアニメーション完了を待機してから要素を取得するように修正

## テスト結果

- 修正後のテストが正常に通ることを確認済み
- 他のテストにも影響なし

## 備考

- UIライブラリのアニメーション付きコンポーネントをテストする際の標準的な対応
- 他の類似テストでも同様の修正が必要になる場合があります